### PR TITLE
add missing default value for "-o" option

### DIFF
--- a/EBG/__main__.py
+++ b/EBG/__main__.py
@@ -17,7 +17,8 @@ def main():
     parser.add_argument("-msa", required=True, type=str, help="PATH\t\tabsolute path to the MSA file in .fasta format ")
     parser.add_argument("-tree", required=True, type=str, help="PATH\t\tabsolute path to the tree file in newick format (.bestTree)")
     parser.add_argument("-model", required=True, type=str, help="PATH\t\tabsolute path to the raxml-ng model file (.bestModel)")
-    parser.add_argument("-o", required=False, type=str, help="VALUE\t\toutput folder name, overwrites all files if already existing\tdefault: EBG_output")
+    parser.add_argument("-o", required=False, type=str, default="EBG_output",
+                        help="VALUE\t\toutput folder name, overwrites all files if already existing\tdefault: EBG_output")
     parser.add_argument("-t", required=False, type=str, default="b",
                         help="c | r | b\t\ttype of prediction: (c)lassification, (r)egression, (b)oth\tdefault: b")
     parser.add_argument("-raxmlng", required=False, type=str, default="raxml-ng",


### PR DESCRIPTION
without `-o`, fails as follows:

```

Traceback (most recent call last):
  File "/home/cipres/miniconda3/envs/ebgenv/bin/ebg", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/cipres/miniconda3/envs/ebgenv/lib/python3.12/site-packages/EBG/__main__.py", line 29, in main
    predictor = Predictor(args.msa, args.tree, args.model, args.o, args.t, args.raxmlng, args.redo)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cipres/miniconda3/envs/ebgenv/lib/python3.12/site-packages/EBG/Prediction/predictor.py", line 64, in __init__
    self.feature_extractor = FeatureExtractor(msa_filepath, tree_filepath, model_filepath, o, raxml_ng_path, redo)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cipres/miniconda3/envs/ebgenv/lib/python3.12/site-packages/EBG/Features/feature_extractor.py", line 36, in __init__
    self.feature_computer = FeatureComputer(msa_file_path, tree_file_path, model_file_path, output_prefix, raxml_ng_path, redo)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cipres/miniconda3/envs/ebgenv/lib/python3.12/site-packages/EBG/Features/feature_computer.py", line 80, in __init__
    tmp_folder_path = os.path.abspath(os.path.join(os.curdir, output_prefix))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 90, in join
  File "<frozen genericpath>", line 164, in _check_arg_types
TypeError: join() argument must be str, bytes, or os.PathLike object, not ‘NoneType'
```